### PR TITLE
[버그 수정] StockCode 존재하는 값만 노출

### DIFF
--- a/SrimCalculator/SrimCalculator/SearchCorpVC.swift
+++ b/SrimCalculator/SrimCalculator/SearchCorpVC.swift
@@ -51,7 +51,7 @@ class SearchCorpVC: UIViewController, UITextFieldDelegate {
             let jsonDecoder = JSONDecoder()
             let dataCorpStruct = try jsonDecoder.decode(CorpCodeStruct.self, from: dataAsset.data)
             
-            self.list = dataCorpStruct.result.list
+            self.list = dataCorpStruct.result.list.filter { $0.stockCode.first != " " }
             self.setSearchCoperationTextField(dataCorpStruct.result.list)
             
         } catch {

--- a/SrimCalculator/SrimCalculator/SearchCorpVC.swift
+++ b/SrimCalculator/SrimCalculator/SearchCorpVC.swift
@@ -89,6 +89,8 @@ class SearchCorpVC: UIViewController, UITextFieldDelegate {
                 financialStatementVC.corpCode = factor.corpCode.first
                 
                 self.navigationController?.pushViewController(tabBarController, animated: true)
+
+                return
             }
         }
         


### PR DESCRIPTION
### StockCode
- StockCode가 존재하지 않는 기업은 재무재표가 탐색되지 않음. (정확한 분석인지 확인이 필요)
- 처음 XML 파일로 가지고 있는 기업에 대해서, StockCode가 존재하는 것들만 조회되도록 리턴값을 변경
![image](https://user-images.githubusercontent.com/26435041/105633920-b5085d00-5e9e-11eb-8478-785a2b3f3d70.png)


### 이름이 같은 기업
- 이름이 같은 기업 (ex. 카카오)이 있을때 두번 화면에 진입되는 현상 수정. 
- 처음으로 기업을 찾으면 바로 리턴하도록 변경