### PR TITLE
5년치 데이터 받아오는 로직 수정

### DIFF
--- a/SrimCalculator/SrimCalculator/Base.lproj/Main.storyboard
+++ b/SrimCalculator/SrimCalculator/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Iqy-jD-DIL">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="b5g-4f-woI">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>

--- a/SrimCalculator/SrimCalculator/Calculator/CalculatorViewController.swift
+++ b/SrimCalculator/SrimCalculator/Calculator/CalculatorViewController.swift
@@ -43,15 +43,6 @@ class CalculatorViewController: UIViewController {
         }
     }
     
-    private func DataForMakingROE(year: Int) -> DataForROE {
-
-        callFinancialData(year: year) { [weak self] financialStatementList in
-            
-        }
-        
-        return DataForROE
-    }
-    
     private func callFinancialData(year: Int, completion:@escaping ([FinancialStatementsList]) -> Void) {
         //        let mycrtfcKey: String = "28223d93326101b760b633b7ab5469df600a465f"
         //            var baseURL: String = "https://opendart.fss.or.kr/api/fnlttSinglAcntAll.json"

--- a/SrimCalculator/SrimCalculator/Table/FinancalStatementTableVC.swift
+++ b/SrimCalculator/SrimCalculator/Table/FinancalStatementTableVC.swift
@@ -115,16 +115,13 @@ class FinancalStatementTableVC: UIViewController {
         for year in 2015...2019 {
             APIInstanceClass.APIfunctionForFinancialStatements(corpCode: self.corpCode ?? "", year: year) { financialData in
                 
-                var year: DataTableValueType = .int(year)
+                let year: DataTableValueType = .int(year)
                 var account: DataTableValueType = .string("")
                 var businessProfit: DataTableValueType = .string("")
                 var netIncome: DataTableValueType = .string("")
                 var EPS: DataTableValueType = .string("")
-                var TotalEquity: DataTableValueType = .string("")
-                
                 
                 for factor in financialData {
-                    
                     if account == .string("") {
                         if factor.sjNm.contains("손익계산서") {
                             account = self.setDataValue(factor, dataType: .account) ?? defaultValue
@@ -164,8 +161,8 @@ class FinancalStatementTableVC: UIViewController {
                         }
                     }
                 }
+                
                 let temporaryData = [year, account, businessProfit, netIncome, EPS]
-//                self.accountDataDelivariedToGraph.append(temp.map { $0.toCGFloat ?? Self.defaultCGFloatValue })
                 self.willUseAccountData.append(temporaryData.map { $0.toDouble ?? Self.defaultDoubleValue})
                 self.updateDataSourece(temporaryData)
             }

--- a/SrimCalculator/SrimCalculator/Table/FinancalStatementTableVC.swift
+++ b/SrimCalculator/SrimCalculator/Table/FinancalStatementTableVC.swift
@@ -155,7 +155,6 @@ class FinancalStatementTableVC: UIViewController {
                         } else if factor.sjNm.contains("포괄손익계산서") {
                             if self.findKeyWord(structFinancalStatement: factor, list: self.EPSWords) {
                                 let factorData = factor.thstrmAmount
-                                //                                let factorData = self.roundToBillion(value: Int(factor.thstrmAmount) ?? 0)
                                 EPS = DataTableValueType.string(factorData)
                             }
                         }

--- a/SrimCalculator/SrimCalculator/Table/FinancalStatementTableVC.swift
+++ b/SrimCalculator/SrimCalculator/Table/FinancalStatementTableVC.swift
@@ -135,41 +135,51 @@ class FinancalStatementTableVC: UIViewController {
         return result ?? .string("")
     }
     
+    private func makeEPSTableValue(_ factor: FinancialStatementsList) -> DataTableValueType {
+        var result: DataTableValueType?
+        
+        if factor.sjNm.contains(Keyword.incomeStatement.title) {
+            if self.findKeyWord(structFinancalStatement: factor, list: self.EPSWords) {
+                let factorData = factor.thstrmAmount
+                result = DataTableValueType.string(factorData)
+            }
+        } else if factor.sjNm.contains(Keyword.comprehensiveIncomeStatement.title) {
+            if self.findKeyWord(structFinancalStatement: factor, list: self.EPSWords) {
+                let factorData = factor.thstrmAmount
+                result = DataTableValueType.string(factorData)
+            }
+        }
+        
+        return result ?? .string("")
+    }
+    
     private func setupAPIData() {
         for year in 2015...2019 {
             APIInstanceClass.APIfunctionForFinancialStatements(corpCode: self.corpCode ?? "", year: year) { financialData in
                 
+                let defaultValue: DataTableValueType = .string("")
+                
                 let year: DataTableValueType = .int(year)
-                var account: DataTableValueType = .string("")
-                var businessProfit: DataTableValueType = .string("")
-                var netIncome: DataTableValueType = .string("")
-                var EPS: DataTableValueType = .string("")
+                var account: DataTableValueType = defaultValue
+                var businessProfit: DataTableValueType = defaultValue
+                var netIncome: DataTableValueType = defaultValue
+                var EPS: DataTableValueType = defaultValue
                 
                 for factor in financialData {
-                    if account == .string("") {
+                    if account == defaultValue {
                         account = self.makeTableValue(factor, currentValueType: .account)
                     }
                     
-                    if businessProfit == .string("") {
+                    if businessProfit == defaultValue {
                         businessProfit = self.makeTableValue(factor, currentValueType: .businessProfit)
                     }
                     
-                    if netIncome == .string("") {
+                    if netIncome == defaultValue {
                         netIncome = self.makeTableValue(factor, currentValueType: .netIncome)
                     }
                     
-                    if EPS == .string("") {
-                        if factor.sjNm.contains(Keyword.incomeStatement.title) {
-                            if self.findKeyWord(structFinancalStatement: factor, list: self.EPSWords) {
-                                let factorData = factor.thstrmAmount
-                                EPS = DataTableValueType.string(factorData)
-                            }
-                        } else if factor.sjNm.contains(Keyword.comprehensiveIncomeStatement.title) {
-                            if self.findKeyWord(structFinancalStatement: factor, list: self.EPSWords) {
-                                let factorData = factor.thstrmAmount
-                                EPS = DataTableValueType.string(factorData)
-                            }
-                        }
+                    if EPS == defaultValue {
+                        EPS = self.makeEPSTableValue(factor)
                     }
                 }
                 

--- a/SrimCalculator/SrimCalculator/Table/FinancalStatementTableVC.swift
+++ b/SrimCalculator/SrimCalculator/Table/FinancalStatementTableVC.swift
@@ -153,37 +153,51 @@ class FinancalStatementTableVC: UIViewController {
         return result ?? .string("")
     }
     
+    private struct DataTableValues {
+        let account: DataTableValueType
+        let businessProfit: DataTableValueType
+        let netIncome: DataTableValueType
+        let EPS: DataTableValueType
+    }
+    
+    private func makeDataValues(_ financialData: [FinancialStatementsList]) -> DataTableValues {
+        
+        let defaultValue: DataTableValueType = .string("")
+        
+        var account: DataTableValueType = defaultValue
+        var businessProfit: DataTableValueType = defaultValue
+        var netIncome: DataTableValueType = defaultValue
+        var EPS: DataTableValueType = defaultValue
+        
+        for factor in financialData {
+            if account == defaultValue {
+                account = self.makeTableValue(factor, currentValueType: .account)
+            }
+            
+            if businessProfit == defaultValue {
+                businessProfit = self.makeTableValue(factor, currentValueType: .businessProfit)
+            }
+            
+            if netIncome == defaultValue {
+                netIncome = self.makeTableValue(factor, currentValueType: .netIncome)
+            }
+            
+            if EPS == defaultValue {
+                EPS = self.makeEPSTableValue(factor)
+            }
+        }
+        
+        return DataTableValues(account: account, businessProfit: businessProfit, netIncome: netIncome, EPS: EPS)
+    }
+    
     private func setupAPIData() {
         for year in 2015...2019 {
             APIInstanceClass.APIfunctionForFinancialStatements(corpCode: self.corpCode ?? "", year: year) { financialData in
                 
-                let defaultValue: DataTableValueType = .string("")
-                
                 let year: DataTableValueType = .int(year)
-                var account: DataTableValueType = defaultValue
-                var businessProfit: DataTableValueType = defaultValue
-                var netIncome: DataTableValueType = defaultValue
-                var EPS: DataTableValueType = defaultValue
+                let tableDataValues = self.makeDataValues(financialData)
+                let temporaryData = [year, tableDataValues.account, tableDataValues.businessProfit, tableDataValues.netIncome, tableDataValues.EPS]
                 
-                for factor in financialData {
-                    if account == defaultValue {
-                        account = self.makeTableValue(factor, currentValueType: .account)
-                    }
-                    
-                    if businessProfit == defaultValue {
-                        businessProfit = self.makeTableValue(factor, currentValueType: .businessProfit)
-                    }
-                    
-                    if netIncome == defaultValue {
-                        netIncome = self.makeTableValue(factor, currentValueType: .netIncome)
-                    }
-                    
-                    if EPS == defaultValue {
-                        EPS = self.makeEPSTableValue(factor)
-                    }
-                }
-                
-                let temporaryData = [year, account, businessProfit, netIncome, EPS]
                 self.willUseAccountData.append(temporaryData.map { $0.toDouble ?? Self.defaultDoubleValue})
                 self.updateDataSourece(temporaryData)
             }

--- a/SrimCalculator/SrimCalculator/Table/FinancalStatementTableVC.swift
+++ b/SrimCalculator/SrimCalculator/Table/FinancalStatementTableVC.swift
@@ -122,46 +122,20 @@ class FinancalStatementTableVC: UIViewController {
         }
     }
     
-    private func makeAccount(_ factor: FinancialStatementsList) -> DataTableValueType {
+    private func makeTableValue(_ factor: FinancialStatementsList, currentValueType: DataValueType) -> DataTableValueType {
+        
         var result: DataTableValueType?
         
         if factor.sjNm.contains(Keyword.incomeStatement.title) {
-            result = self.setDataValue(factor, dataType: .account)
+            result = self.setDataValue(factor, dataType: currentValueType)
         } else if factor.sjNm.contains(Keyword.comprehensiveIncomeStatement.title) {
-            result = self.setDataValue(factor, dataType: .account)
-        }
-        
-        return result ?? .string("")
-    }
-    
-    private func makeBusinessProfit(_ factor: FinancialStatementsList) -> DataTableValueType {
-        var result: DataTableValueType?
-        
-        if factor.sjNm.contains(Keyword.incomeStatement.title) {
-            result = self.setDataValue(factor, dataType: .businessProfit)
-        } else if factor.sjNm.contains(Keyword.comprehensiveIncomeStatement.title) {
-            result = self.setDataValue(factor, dataType: .businessProfit)
-        }
-        
-        return result ?? .string("")
-    }
-    
-    private func makeNetIncome(_ factor: FinancialStatementsList) -> DataTableValueType {
-        var result: DataTableValueType?
-        
-        if factor.sjNm.contains(Keyword.incomeStatement.title) {
-            result = self.setDataValue(factor, dataType: .netIncome)
-        } else if factor.sjNm.contains(Keyword.comprehensiveIncomeStatement.title) {
-            result = self.setDataValue(factor, dataType: .netIncome)
+            result = self.setDataValue(factor, dataType: currentValueType)
         }
         
         return result ?? .string("")
     }
     
     private func setupAPIData() {
-        
-        let defaultValue: DataTableValueType = .string("")
-        
         for year in 2015...2019 {
             APIInstanceClass.APIfunctionForFinancialStatements(corpCode: self.corpCode ?? "", year: year) { financialData in
                 
@@ -173,15 +147,15 @@ class FinancalStatementTableVC: UIViewController {
                 
                 for factor in financialData {
                     if account == .string("") {
-                        account = self.makeAccount(factor)
+                        account = self.makeTableValue(factor, currentValueType: .account)
                     }
                     
                     if businessProfit == .string("") {
-                        businessProfit = self.makeBusinessProfit(factor)
+                        businessProfit = self.makeTableValue(factor, currentValueType: .businessProfit)
                     }
                     
                     if netIncome == .string("") {
-                        netIncome = self.makeNetIncome(factor)
+                        netIncome = self.makeTableValue(factor, currentValueType: .netIncome)
                     }
                     
                     if EPS == .string("") {

--- a/SrimCalculator/SrimCalculator/Table/FinancalStatementTableVC.swift
+++ b/SrimCalculator/SrimCalculator/Table/FinancalStatementTableVC.swift
@@ -112,7 +112,7 @@ class FinancalStatementTableVC: UIViewController {
         
         let defaultValue: DataTableValueType = .string("")
         
-        for year in 2010...2019 {
+        for year in 2015...2019 {
             APIInstanceClass.APIfunctionForFinancialStatements(corpCode: self.corpCode ?? "", year: year) { financialData in
                 
                 var year: DataTableValueType = .int(year)

--- a/SrimCalculator/SrimCalculator/Table/FinancalStatementTableVC.swift
+++ b/SrimCalculator/SrimCalculator/Table/FinancalStatementTableVC.swift
@@ -108,6 +108,20 @@ class FinancalStatementTableVC: UIViewController {
         return nil
     }
     
+    private enum Keyword {
+        case incomeStatement
+        case comprehensiveIncomeStatement
+        
+        var title: String {
+            switch self {
+            case .incomeStatement:
+                return "손익계산서"
+            case .comprehensiveIncomeStatement:
+                return "포괄손익계산서"
+            }
+        }
+    }
+    
     private func setupAPIData() {
         
         let defaultValue: DataTableValueType = .string("")
@@ -123,36 +137,36 @@ class FinancalStatementTableVC: UIViewController {
                 
                 for factor in financialData {
                     if account == .string("") {
-                        if factor.sjNm.contains("손익계산서") {
+                        if factor.sjNm.contains(Keyword.incomeStatement.title) {
                             account = self.setDataValue(factor, dataType: .account) ?? defaultValue
-                        } else if factor.sjNm.contains("포괄손익계산서") {
+                        } else if factor.sjNm.contains(Keyword.comprehensiveIncomeStatement.title) {
                             account = self.setDataValue(factor, dataType: .account) ?? defaultValue
                         }
                     }
                     
                     if businessProfit == .string("") {
-                        if factor.sjNm.contains("손익계산서") {
+                        if factor.sjNm.contains(Keyword.incomeStatement.title) {
                             businessProfit = self.setDataValue(factor, dataType: .businessProfit) ?? defaultValue
-                        } else if factor.sjNm.contains("포괄손익계산서") {
+                        } else if factor.sjNm.contains(Keyword.comprehensiveIncomeStatement.title) {
                             businessProfit = self.setDataValue(factor, dataType: .businessProfit) ?? defaultValue
                         }
                     }
                     
                     if netIncome == .string("") {
-                        if factor.sjNm.contains("손익계산서") {
+                        if factor.sjNm.contains(Keyword.incomeStatement.title) {
                             netIncome = self.setDataValue(factor, dataType: .netIncome) ?? defaultValue
-                        } else if factor.sjNm.contains("포괄손익계산서") {
+                        } else if factor.sjNm.contains(Keyword.comprehensiveIncomeStatement.title) {
                             netIncome = self.setDataValue(factor, dataType: .netIncome) ?? defaultValue
                         }
                     }
                     
                     if EPS == .string("") {
-                        if factor.sjNm.contains("손익계산서") {
+                        if factor.sjNm.contains(Keyword.incomeStatement.title) {
                             if self.findKeyWord(structFinancalStatement: factor, list: self.EPSWords) {
                                 let factorData = factor.thstrmAmount
                                 EPS = DataTableValueType.string(factorData)
                             }
-                        } else if factor.sjNm.contains("포괄손익계산서") {
+                        } else if factor.sjNm.contains(Keyword.comprehensiveIncomeStatement.title) {
                             if self.findKeyWord(structFinancalStatement: factor, list: self.EPSWords) {
                                 let factorData = factor.thstrmAmount
                                 EPS = DataTableValueType.string(factorData)

--- a/SrimCalculator/SrimCalculator/Table/FinancalStatementTableVC.swift
+++ b/SrimCalculator/SrimCalculator/Table/FinancalStatementTableVC.swift
@@ -122,6 +122,42 @@ class FinancalStatementTableVC: UIViewController {
         }
     }
     
+    private func makeAccount(_ factor: FinancialStatementsList) -> DataTableValueType {
+        var result: DataTableValueType?
+        
+        if factor.sjNm.contains(Keyword.incomeStatement.title) {
+            result = self.setDataValue(factor, dataType: .account)
+        } else if factor.sjNm.contains(Keyword.comprehensiveIncomeStatement.title) {
+            result = self.setDataValue(factor, dataType: .account)
+        }
+        
+        return result ?? .string("")
+    }
+    
+    private func makeBusinessProfit(_ factor: FinancialStatementsList) -> DataTableValueType {
+        var result: DataTableValueType?
+        
+        if factor.sjNm.contains(Keyword.incomeStatement.title) {
+            result = self.setDataValue(factor, dataType: .businessProfit)
+        } else if factor.sjNm.contains(Keyword.comprehensiveIncomeStatement.title) {
+            result = self.setDataValue(factor, dataType: .businessProfit)
+        }
+        
+        return result ?? .string("")
+    }
+    
+    private func makeNetIncome(_ factor: FinancialStatementsList) -> DataTableValueType {
+        var result: DataTableValueType?
+        
+        if factor.sjNm.contains(Keyword.incomeStatement.title) {
+            result = self.setDataValue(factor, dataType: .netIncome)
+        } else if factor.sjNm.contains(Keyword.comprehensiveIncomeStatement.title) {
+            result = self.setDataValue(factor, dataType: .netIncome)
+        }
+        
+        return result ?? .string("")
+    }
+    
     private func setupAPIData() {
         
         let defaultValue: DataTableValueType = .string("")
@@ -137,27 +173,15 @@ class FinancalStatementTableVC: UIViewController {
                 
                 for factor in financialData {
                     if account == .string("") {
-                        if factor.sjNm.contains(Keyword.incomeStatement.title) {
-                            account = self.setDataValue(factor, dataType: .account) ?? defaultValue
-                        } else if factor.sjNm.contains(Keyword.comprehensiveIncomeStatement.title) {
-                            account = self.setDataValue(factor, dataType: .account) ?? defaultValue
-                        }
+                        account = self.makeAccount(factor)
                     }
                     
                     if businessProfit == .string("") {
-                        if factor.sjNm.contains(Keyword.incomeStatement.title) {
-                            businessProfit = self.setDataValue(factor, dataType: .businessProfit) ?? defaultValue
-                        } else if factor.sjNm.contains(Keyword.comprehensiveIncomeStatement.title) {
-                            businessProfit = self.setDataValue(factor, dataType: .businessProfit) ?? defaultValue
-                        }
+                        businessProfit = self.makeBusinessProfit(factor)
                     }
                     
                     if netIncome == .string("") {
-                        if factor.sjNm.contains(Keyword.incomeStatement.title) {
-                            netIncome = self.setDataValue(factor, dataType: .netIncome) ?? defaultValue
-                        } else if factor.sjNm.contains(Keyword.comprehensiveIncomeStatement.title) {
-                            netIncome = self.setDataValue(factor, dataType: .netIncome) ?? defaultValue
-                        }
+                        netIncome = self.makeNetIncome(factor)
                     }
                     
                     if EPS == .string("") {


### PR DESCRIPTION
### 작업 사항
- 10년치 데이터 받아오던 것을 5년치로 변경 (애초에 2015년 부터 받을 수 있음) 6e25bb2
- 사용하지 않는 주석들 제거 6dd3bb1, 656478c
- 스트링 값으로 사용하던, 손익 계산서, 포괄 손익 계산서를 enum 으로 처리 2239eed
- 중복코드를 하나의 함수에서 처리 f181ea1, 106d912
- account, businessProfit, netIncome, EPS를 포함한 Struct 생성후 For문을 함수에서 처리 6687399