### PR TITLE
[테이블] 연도 별로 소팅하는 기능 추가

### DIFF
--- a/SrimCalculator/SrimCalculator/Table/FinancalStatementTableVC.swift
+++ b/SrimCalculator/SrimCalculator/Table/FinancalStatementTableVC.swift
@@ -199,6 +199,7 @@ class FinancalStatementTableVC: UIViewController {
     private func updateDataSourece(_ dataSource: [DataTableValueType]) {
         DispatchQueue.main.async {
             self.dataSource.append(dataSource)
+            self.dataSource.sort { $0[0] < $1[0] }
             self.dataTable.reload()
         }
     }

--- a/SrimCalculator/SrimCalculator/Table/FinancalStatementTableVC.swift
+++ b/SrimCalculator/SrimCalculator/Table/FinancalStatementTableVC.swift
@@ -197,9 +197,11 @@ class FinancalStatementTableVC: UIViewController {
     static var defaultDoubleValue: Double = -1
     
     private func updateDataSourece(_ dataSource: [DataTableValueType]) {
+        let defaultYear: DataTableValueType = .int(0)
+        
         DispatchQueue.main.async {
             self.dataSource.append(dataSource)
-            self.dataSource.sort { $0[0] < $1[0] }
+            self.dataSource.sort { $0.first ?? defaultYear < $1.first ?? defaultYear }
             self.dataTable.reload()
         }
     }

--- a/SrimCalculator/SrimCalculator/Table/FinancalStatementTableVC.swift
+++ b/SrimCalculator/SrimCalculator/Table/FinancalStatementTableVC.swift
@@ -25,14 +25,7 @@ class FinancalStatementTableVC: UIViewController {
     let EPSWords: [String] = ["기본 및 희석 보통주당이익", "기본 및 희석주당이익", "기본 및 희석주당이익(보통주)", "기본/희석주당순이익", "기본및희석주당계속영업이익", "기본및희석주당이익", "기본및희석주당이익(손실)","기본주당손익", "기본주당순이익", "기본주당이익", "기본주당이익(손실)", "보통주 기본 및 희석주당손익", "보통주 기본 및 희석주당이익(손실)", "보통주 기본및희석주당손익", "보통주 기본주당이익", "보통주기본주당순이익", "보통주기본주당순이익(손실)", "보통주기본주당이익", "보통주희석주당이익", "기본주당이익(손실) (단위:원)","기본주당이익(원)","보통주 기본 및 희석주당이익 (단위: 원)","기본주당계속영업이익","보통주 기본주당손익","기본주당순이익(손실)"]
     
     var dataDelivariedToGraph:[CGFloat] = [20, 10, 30, 20, 50, 100, 10, 10]
-    
-//    var accountDataDelivariedToGraph: [[CGFloat]] = []
     var willUseAccountData: [[Double]] = []
-    
-    //    case account
-    //    case businessProfit
-    //    case netIncome
-    //    case EPS
     
     private let APIInstanceClass = APIClass()
     
@@ -46,9 +39,7 @@ class FinancalStatementTableVC: UIViewController {
     
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-//        if let graphViewController = self.tabBarController?.viewControllers?[1] as? GraphViewController {
-//            graphViewController.takingdataOftable = accountDataDelivariedToGraph
-//        }
+
         if let chartViewController = self.tabBarController?.viewControllers?[2] as? ChartsViewController {
             chartViewController.useForMakingCharts = willUseAccountData
         }
@@ -96,7 +87,6 @@ class FinancalStatementTableVC: UIViewController {
     
     private func setDataValue(_ factor: FinancialStatementsList, dataType: DataValueType) -> DataTableValueType? {
         if self.findKeyWord(structFinancalStatement: factor, list: dataType.words) {
-            //                                let factorData = factor.thstrmAmount
             do {
                 let factorData = try self.roundToBillion(value: Int(factor.thstrmAmount) ?? 0)
                 return DataTableValueType.string(factorData ?? "")
@@ -238,8 +228,6 @@ class FinancalStatementTableVC: UIViewController {
         
         for index in 0..<list.count {
             if structFinancalStatement.accountNm == list[index] {
-                //                structFinancalStatement.accountNm.contains(list[word])
-                print(list[index])
                 return true
             }
         }


### PR DESCRIPTION
**[작업 내용]**
- 연도별로 세팅 할 수 있도록 기능 추가
  - 처음에는 2015~2019년 5개년치의 API 요청을 하고, 5개의 요청이 모두 끝낫을때 DispatchGroup을 사용해서 끝난 시점을 파악 하려 했으나. 생각대로 잘 동작 하지 않음. (API에 대한 이해도가 낮은 것도 있고, 애초에 서버에서 한번요청하면 5개년치를 한번에 내려주는게 더 효율적이라고 생각함)
  - 어차피 년도별로 sorting 하는 로직은 필요하므로, dataSource에 들어간 데이터를 Sorting 하도록함. (현재는 년도별 데이터가 내려올때마다 소팅을 하고있음. 더 좋은 방식은 5개년치 데이터를 한번에 받아와서 소팅하거나, 소팅된채로 내려오는게 가장 베스트라고 생가함)
- 플러스로 필요없는 주석 제거
 

AS-IS|TO-BE
--|--
<img src="https://user-images.githubusercontent.com/26435041/107138198-68b92480-6956-11eb-8869-6445fd5e08c7.png" width="240">|<img src="https://user-images.githubusercontent.com/26435041/107138201-72db2300-6956-11eb-9973-bc336c9197e2.png" width="240">
